### PR TITLE
Allow to provide tags condition in form of TagLine, not only as an expression

### DIFF
--- a/api/rpc/querier.go
+++ b/api/rpc/querier.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jrivets/log4g"
 	"github.com/logrange/logrange/api"
 	"github.com/logrange/logrange/pkg/cursor"
-	"github.com/logrange/logrange/pkg/lql"
 	"github.com/logrange/logrange/pkg/model"
 	"github.com/logrange/logrange/pkg/tindex"
 	"github.com/logrange/range/pkg/records"
@@ -159,14 +158,7 @@ func (sq *ServerQuerier) sources(reqId int32, reqBody []byte, sc *rrpc.ServerCon
 		return
 	}
 
-	se, err := lql.ParseExpr(tagsCond)
-	if err != nil {
-		sq.logger.Warn("sources(): could not parse ", tagsCond, " body err=", err)
-		sc.SendResponse(reqId, err, cEmptyResponse)
-		return
-	}
-
-	mp, count, err := sq.TIndex.GetJournals(se, 100, true)
+	mp, count, err := sq.TIndex.GetJournals(tagsCond, 100, true)
 	if err != nil {
 		sq.logger.Warn("sources(): could not obtain sources err=", err)
 		sc.SendResponse(reqId, err, cEmptyResponse)

--- a/cmd/logrange/main.go
+++ b/cmd/logrange/main.go
@@ -36,7 +36,6 @@ const (
 	argStartCfgFile    = "config-file"
 	argStartHostHostId = "host-id"
 	argStartJournalDir = "journals-dir"
-	argStartNewTIdxOk  = "new-tindex-ok"
 )
 
 var cfg = server.GetDefaultConfig()
@@ -71,10 +70,6 @@ func main() {
 						Name:  argStartJournalDir,
 						Usage: "Defines path to the journals database directory",
 						Value: cfg.JrnlCtrlConfig.JournalsDir,
-					},
-					&cli.BoolFlag{
-						Name:  argStartNewTIdxOk,
-						Usage: "Create a new tag-index if there is none",
 					},
 				},
 			},
@@ -120,9 +115,6 @@ func applyArgsToCfg(c *cli.Context, cfg *server.Config) {
 	}
 	if jd := c.String(argStartJournalDir); dc.JrnlCtrlConfig.JournalsDir != jd {
 		cfg.JrnlCtrlConfig.JournalsDir = jd
-	}
-	if newIdx := c.Bool(argStartNewTIdxOk); newIdx {
-		cfg.NewTIndexOk = true
 	}
 }
 

--- a/pkg/cursor/cursor.go
+++ b/pkg/cursor/cursor.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/logrange/logrange/pkg/lql"
 	"github.com/logrange/logrange/pkg/model"
 	"github.com/logrange/logrange/pkg/tindex"
 	"github.com/logrange/range/pkg/records/journal"
@@ -64,13 +63,7 @@ const cMaxSources = 50
 
 // newCursor creates the new cursor based on the state provided.
 func newCursor(ctx context.Context, state State, tidx tindex.Service, jctrl journal.Controller) (*Cursor, error) {
-	// figuring out the journals list
-	se, err := lql.ParseExpr(state.Sources)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Could not parse expression \"%s\" ", state.Where)
-	}
-
-	srcs, _, err := tidx.GetJournals(se, cMaxSources+1, false)
+	srcs, _, err := tidx.GetJournals(state.Sources, cMaxSources+1, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could not get a list of journals for the expression \"%s\"", state.Sources)
 	}

--- a/pkg/cursor/cursort_test.go
+++ b/pkg/cursor/cursort_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestNewCursor(t *testing.T) {
-	if _, err := newCursor(nil, State{Sources: "ddd"}, nil, nil); err == nil {
+	if _, err := newCursor(nil, State{Sources: "ddd"}, &testTidxService{}, nil); err == nil {
 		t.Fatal("err must not be nil, Source expression compilation must fail")
 	}
 

--- a/pkg/cursor/mocks.go
+++ b/pkg/cursor/mocks.go
@@ -16,7 +16,6 @@ package cursor
 import (
 	"context"
 	"fmt"
-	"github.com/logrange/logrange/pkg/lql"
 	"github.com/logrange/logrange/pkg/model"
 	"github.com/logrange/range/pkg/records"
 	"github.com/logrange/range/pkg/records/journal"
@@ -31,7 +30,7 @@ func (tis *testTidxService) GetOrCreateJournal(tags string) (string, error) {
 	return "", nil
 }
 
-func (tis *testTidxService) GetJournals(exp *lql.Expression, maxSize int, checkAll bool) (map[model.TagLine]string, int, error) {
+func (tis *testTidxService) GetJournals(tagsCond string, maxSize int, checkAll bool) (map[model.TagLine]string, int, error) {
 	return tis.journals, len(tis.journals), nil
 }
 

--- a/pkg/cursor/mocks.go
+++ b/pkg/cursor/mocks.go
@@ -47,6 +47,14 @@ func (tjc *testJrnlCtrlr) GetOrCreate(ctx context.Context, jname string) (journa
 	return nil, fmt.Errorf("Journal %s is not found", jname)
 }
 
+func (tjc *testJrnlCtrlr) GetJournals(ctx context.Context) []string {
+	res := make([]string, 0, len(tjc.mp))
+	for src := range tjc.mp {
+		res = append(res, src)
+	}
+	return res
+}
+
 type testJrnl struct {
 	name string
 }

--- a/pkg/tindex/inmem.go
+++ b/pkg/tindex/inmem.go
@@ -45,8 +45,8 @@ type (
 	}
 
 	inmemService struct {
-		Config *InMemConfig       `inject:"inmemServiceConfig"`
-		JCtrlr journal.Controller `inject:""`
+		Config   *InMemConfig       `inject:"inmemServiceConfig"`
+		Journals journal.Controller `inject:""`
 
 		logger log4g.Logger
 		lock   sync.Mutex
@@ -195,7 +195,7 @@ func (ims *inmemService) checkConsistency(ctx context.Context) error {
 	}
 
 	ims.logger.Info("Checking the index and data consistency")
-	knwnJrnls := ims.JCtrlr.GetJournals(ctx)
+	knwnJrnls := ims.Journals.GetJournals(ctx)
 	fail := false
 	km := make(map[string]string, len(ims.tmap))
 	for _, d := range ims.tmap {

--- a/pkg/tindex/inmem.go
+++ b/pkg/tindex/inmem.go
@@ -126,8 +126,8 @@ func (ims *inmemService) GetOrCreateJournal(tags string) (string, error) {
 	return res, nil
 }
 
-func (ims *inmemService) GetJournals(exp *lql.Expression, maxSize int, checkAll bool) (map[model.TagLine]string, int, error) {
-	tef, err := lql.BuildTagsExpFunc(exp)
+func (ims *inmemService) GetJournals(tagsCond string, maxSize int, checkAll bool) (map[model.TagLine]string, int, error) {
+	tef, err := lql.BuildTagsExpFunc(tagsCond)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -141,7 +141,7 @@ func (ims *inmemService) GetJournals(exp *lql.Expression, maxSize int, checkAll 
 	count := 0
 	res := make(map[model.TagLine]string, 10)
 	for _, td := range ims.tmap {
-		if tef(td.Tags.GetTagMap()) {
+		if tef(td.Tags) {
 			count++
 			if len(res) < maxSize {
 				res[td.Tags.GetTagLine()] = td.Src

--- a/pkg/tindex/inmem_test.go
+++ b/pkg/tindex/inmem_test.go
@@ -24,15 +24,15 @@ import (
 	"testing"
 )
 
-type testJrnlCtrlr struct {
+type testJournals struct {
 	js []string
 }
 
-func (tjc *testJrnlCtrlr) GetJournals(ctx context.Context) []string {
+func (tjc *testJournals) GetJournals(ctx context.Context) []string {
 	return tjc.js
 }
 
-func (tjc *testJrnlCtrlr) GetOrCreate(ctx context.Context, jname string) (journal.Journal, error) {
+func (tjc *testJournals) GetOrCreate(ctx context.Context, jname string) (journal.Journal, error) {
 	return nil, nil
 }
 
@@ -45,7 +45,7 @@ func BenchmarkFindIndex(b *testing.B) {
 
 	ims := NewInmemService().(*inmemService)
 	ims.Config = &InMemConfig{WorkingDir: dir}
-	ims.JCtrlr = &testJrnlCtrlr{}
+	ims.Journals = &testJournals{}
 	ims.Init(nil)
 	tags := "a=b|c=asdfasdfasdf"
 	src, err := ims.GetOrCreateJournal(tags)
@@ -71,7 +71,7 @@ func TestCheckInit(t *testing.T) {
 	defer os.RemoveAll(dir) // clean up
 
 	ims := NewInmemService().(*inmemService)
-	ims.JCtrlr = &testJrnlCtrlr{}
+	ims.Journals = &testJournals{}
 	ims.Config = &InMemConfig{WorkingDir: dir, DoNotSave: false}
 	err = ims.Init(nil)
 	if err != nil {
@@ -85,14 +85,14 @@ func TestCheckInit(t *testing.T) {
 	t.Log(jrnl)
 	ims.Shutdown()
 
-	ims.JCtrlr = &testJrnlCtrlr{[]string{jrnl}}
+	ims.Journals = &testJournals{[]string{jrnl}}
 	err = ims.Init(nil)
 	if err != nil {
 		t.Fatal("err must be nil, but err=", err)
 	}
 	ims.Shutdown()
 
-	ims.JCtrlr = &testJrnlCtrlr{[]string{jrnl, "1234"}}
+	ims.Journals = &testJournals{[]string{jrnl, "1234"}}
 	err = ims.Init(nil)
 	if err == nil {
 		t.Fatal("err is nil, but must not be")
@@ -108,7 +108,7 @@ func TestCheckLoadReload(t *testing.T) {
 	log4g.SetLogLevel("", log4g.DEBUG)
 
 	ims := NewInmemService().(*inmemService)
-	ims.JCtrlr = &testJrnlCtrlr{}
+	ims.Journals = &testJournals{}
 	ims.Config = &InMemConfig{WorkingDir: dir}
 	err = ims.Init(nil)
 	if err != nil {
@@ -150,7 +150,7 @@ func TestGetJournals(t *testing.T) {
 	defer os.RemoveAll(dir) // clean up
 
 	ims := NewInmemService().(*inmemService)
-	ims.JCtrlr = &testJrnlCtrlr{}
+	ims.Journals = &testJournals{}
 	ims.Config = &InMemConfig{WorkingDir: dir, DoNotSave: true}
 	ims.Init(nil)
 	tags := "dda=basdfasdf|c=asdfasdfasdf"
@@ -198,7 +198,7 @@ func TestGetJournalsLimits(t *testing.T) {
 	defer os.RemoveAll(dir) // clean up
 
 	ims := NewInmemService().(*inmemService)
-	ims.JCtrlr = &testJrnlCtrlr{}
+	ims.Journals = &testJournals{}
 	ims.Config = &InMemConfig{WorkingDir: dir, DoNotSave: true}
 	ims.Init(nil)
 	ims.GetOrCreateJournal("name=app1|ip=123")

--- a/pkg/tindex/inmem_test.go
+++ b/pkg/tindex/inmem_test.go
@@ -17,7 +17,6 @@ package tindex
 import (
 	"context"
 	"github.com/jrivets/log4g"
-	"github.com/logrange/logrange/pkg/lql"
 	"github.com/logrange/logrange/pkg/model"
 	"github.com/logrange/range/pkg/records/journal"
 	"io/ioutil"
@@ -164,24 +163,27 @@ func TestGetJournals(t *testing.T) {
 	t2, _ := model.NewTags(tags2)
 	tl2 := t2.GetTagLine()
 
-	exp, err := lql.ParseExpr("dda=basdfasdf")
-	if err != nil {
-		t.Fatal("err must be nil, but ", err)
-	}
-
-	res, _, err := ims.GetJournals(exp, 10, false)
+	res, _, err := ims.GetJournals("dda=basdfasdf", 10, false)
 	if err != nil || len(res) != 2 || res[tl1] != src || res[tl2] != src2 {
 		t.Fatal("err=", err, " res=", res, ", Src=", src, ", src2=", src2)
 	}
 
-	exp, _ = lql.ParseExpr("dda=basdfasdf  and c=asdfasdfasdf")
-	res, _, err = ims.GetJournals(exp, 10, false)
+	res, _, err = ims.GetJournals("dda=basdfasdf  and c=asdfasdfasdf", 10, false)
 	if err != nil || len(res) != 1 || res[tl1] != src {
 		t.Fatal("err=", err, " res=", res, ", Src=", src)
 	}
 
-	exp, _ = lql.ParseExpr("a=234")
-	res, _, err = ims.GetJournals(exp, 5, false)
+	res, _, err = ims.GetJournals("c=asdfasdfasdf|dda=basdfasdf", 10, false)
+	if err != nil || len(res) != 1 || res[tl1] != src {
+		t.Fatal("err=", err, " res=", res, ", Src=", src)
+	}
+
+	res, _, err = ims.GetJournals(tags, 10, false)
+	if err != nil || len(res) != 1 || res[tl1] != src {
+		t.Fatal("err=", err, " res=", res, ", Src=", src)
+	}
+
+	res, _, err = ims.GetJournals("a=234", 5, false)
 	if err != nil || len(res) != 0 {
 		t.Fatal("err=", err, " res=", res)
 	}
@@ -203,22 +205,17 @@ func TestGetJournalsLimits(t *testing.T) {
 	ims.GetOrCreateJournal("name=app1|ip=1233")
 	ims.GetOrCreateJournal("name=app1|ip=12334")
 
-	exp, err := lql.ParseExpr("name=app1")
-	if err != nil {
-		t.Fatal("err must be nil, but ", err)
-	}
-
-	res, _, err := ims.GetJournals(exp, 1, false)
+	res, _, err := ims.GetJournals("name=app1", 1, false)
 	if err != nil || len(res) != 1 {
 		t.Fatal("err=", err, " res=", res)
 	}
 
-	res, cnt, err := ims.GetJournals(exp, 10, true)
+	res, cnt, err := ims.GetJournals("name=app1", 10, true)
 	if err != nil || len(res) != 3 || cnt != 3 {
 		t.Fatal("err=", err, " res=", res, ", cnt=", cnt)
 	}
 
-	res, cnt, err = ims.GetJournals(exp, 2, false)
+	res, cnt, err = ims.GetJournals("name=app1", 2, false)
 	if err != nil || len(res) != 2 || cnt != 3 {
 		t.Fatal("err=", err, " res=", res, ", cnt=", cnt)
 	}

--- a/pkg/tindex/tindex.go
+++ b/pkg/tindex/tindex.go
@@ -15,7 +15,6 @@
 package tindex
 
 import (
-	"github.com/logrange/logrange/pkg/lql"
 	"github.com/logrange/logrange/pkg/model"
 )
 
@@ -29,6 +28,6 @@ type (
 		// GetJournals returns map of matched Tags to the journals they address by the source expression
 		// the function receive maxSize of the result map and the flag checkAll which allows to count total matches found.
 		// It returns the result map, number or matches in total (if checkAll is provided) and an error if any
-		GetJournals(exp *lql.Expression, maxSize int, checkAll bool) (map[model.TagLine]string, int, error)
+		GetJournals(tagsCond string, maxSize int, checkAll bool) (map[model.TagLine]string, int, error)
 	}
 )

--- a/server/server.go
+++ b/server/server.go
@@ -33,7 +33,7 @@ func Start(ctx context.Context, cfg *Config) error {
 	log := log4g.GetLogger("server")
 	log.Info("Start with config:", cfg)
 
-	imsCfg := &tindex.InMemConfig{WorkingDir: cfg.JrnlCtrlConfig.JournalsDir, CreateNew: cfg.NewTIndexOk}
+	imsCfg := &tindex.InMemConfig{WorkingDir: cfg.JrnlCtrlConfig.JournalsDir}
 
 	injector := linker.New()
 	injector.SetLogger(log4g.GetLogger("injector"))


### PR DESCRIPTION
It allows to set conditions either:
`name=app1 and pod=12341234`
or
`name=app1|pod=12341234` 

forms, which are equivalent. The `name=app1|pod=12341234 ` is equal to tags AND expression
